### PR TITLE
Updated module.json to fix fr.json language path

### DIFF
--- a/module.json
+++ b/module.json
@@ -24,7 +24,7 @@
         {
             "lang": "fr",
             "name": "Français",
-            "path": "languages/fr.json"
+            "path": "lang/fr.json"
         },
         {
             "lang": "ja",


### PR DESCRIPTION
The old path showed "languages/fr.json" but that directory is invalid, it should be "lang/fr.json". Verified French works properly now.